### PR TITLE
Added 'raw' markdown and 'preview' views 

### DIFF
--- a/components/pages/CreateCodeOfConductPage.tsx
+++ b/components/pages/CreateCodeOfConductPage.tsx
@@ -6,10 +6,11 @@ import { useToast } from "../ui/use-toast";
 import { conductFormData } from "@/types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Button } from "../ui/button";
-import { Check, CopyIcon } from "lucide-react";
+import { Check, CopyIcon, GripVertical } from "lucide-react";
 import RenderMarkdown from "../RenderMarkdown";
 import CreateCodeOfConductForm from "../CreateCodeOfConductForm";
 import { GenerateContentWithAI } from "@/actions/AIGeneration";
+import {Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 type Props = {
     themeFiles: string[];
@@ -25,6 +26,7 @@ const CreateCodeOfConductPage = ({ themeFiles, markdownPath }: Props) => {
     });
     const [themeContent, setThemeContent] = useState("");
     const [isCopied, setIsCopied] = useState(false);
+    const [isRawMode, setIsRawMode] = useState(false);
     const [generating, setGenerating] = useState(false);
 
     const getThemeData = async () => {
@@ -53,6 +55,10 @@ const CreateCodeOfConductPage = ({ themeFiles, markdownPath }: Props) => {
         }, 2000)
     }
 
+    const handleMarkdownChange = (e:React.ChangeEvent<HTMLTextAreaElement>)=>{
+        setThemeContent(e.target.value);
+    }
+    
     const getAIText = async () => {
         setGenerating(true);
         const systemPrompt = "You are an AI that can write SEO friendly README for github Projects. Write the content for the description section of this REAMDE in about 100 words. Use emojis, bullet points and make the README as attractive as possible.";
@@ -64,13 +70,16 @@ const CreateCodeOfConductPage = ({ themeFiles, markdownPath }: Props) => {
     return (
         <div className='w-full p-4 min-h-screen h-auto bg-gray-50 dark:bg-zinc-900'>
             <CreateCodeOfConductForm formData={formData} setFormData={setFormData} handleButtonClick={handleButtonClick} getAIText={getAIText} isAIGenerating={generating} />
-            <div className="w-full shadow-lg rounded-lg h-full bg-background dark:shadow-zinc-600">
+            <div className="w-full pb-2 shadow-lg rounded-lg h-full bg-background dark:shadow-zinc-600">
                 <div className="flex gap-4 w-full justify-end p-2">
                     <Button variant={"outline"} className={`h-[40px] w-[40px] p-0 ${isCopied && "bg-green-300 hover:bg-green-300"}`} onClick={handleContentCopy}>
                         {!isCopied ?
                             <CopyIcon size={20} />
                             : <Check />
                         }
+                    </Button>
+                    <Button variant={'outline'} className={`h-[40px] w-32 p-0`} onClick={()=>setIsRawMode(!isRawMode)}>
+                        {isRawMode ? 'Raw + Preview': 'Preview only'}
                     </Button>
                     <Select onValueChange={(value) => setSelectedTheme(value)}>
                         <SelectTrigger className="w-[180px]">
@@ -84,7 +93,32 @@ const CreateCodeOfConductPage = ({ themeFiles, markdownPath }: Props) => {
                     </Select>
                 </div>
 
-                <RenderMarkdown themeContent={themeContent} />
+                <PanelGroup direction="horizontal">
+                    <Panel id="preview" order={1} defaultSize={isRawMode ? 49 : 100}>
+                        <div>
+                        <RenderMarkdown themeContent={themeContent} />
+                        </div>
+                    </Panel>
+                    {isRawMode ? (
+                        <>
+                            <PanelResizeHandle className="flex justify-center items-center w-px mx-4 bg-slate-600">
+                                <div className="z-10 flex h-full w-6 items-center justify-center rounded">
+                                    <GripVertical className="bg-white dark:bg-background" />
+                                </div>
+                            </PanelResizeHandle>
+                            <Panel id="raw" order={2} defaultSize={51}>
+                                <div className="h-full mr-2">
+                                <textarea 
+                                    value={themeContent} 
+                                    onChange={handleMarkdownChange}
+                                    className="w-full h-full p-4 rounded-lg text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-white"
+                                />
+                                </div>
+                            </Panel>
+                        </>
+                    ) : (<></>)
+                } 
+                </PanelGroup>
             </div>
         </div>
     )

--- a/components/pages/CreateGuidelinesPage.tsx
+++ b/components/pages/CreateGuidelinesPage.tsx
@@ -6,10 +6,11 @@ import { useToast } from "../ui/use-toast";
 import { guidelinesFormData } from "@/types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Button } from "../ui/button";
-import { Check, CopyIcon } from "lucide-react";
+import { Check, CopyIcon, GripVertical } from "lucide-react";
 import CreateGuidelinesForm from "../CreateGuidelinesForm";
 import RenderMarkdown from "../RenderMarkdown";
 import { GenerateContentWithAI } from "@/actions/AIGeneration";
+import {Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 type Props = {
     themeFiles: string[];
@@ -25,6 +26,7 @@ const CreateGuidelinesPage = ({ themeFiles, markdownPath }: Props) => {
     });
     const [themeContent, setThemeContent] = useState("");
     const [isCopied, setIsCopied] = useState(false);
+    const [isRawMode, setIsRawMode] = useState(false);
     const [generating, setGenerating] = useState(false);
 
     const getThemeData = async () => {
@@ -53,6 +55,10 @@ const CreateGuidelinesPage = ({ themeFiles, markdownPath }: Props) => {
         }, 2000)
     }
 
+    const handleMarkdownChange = (e:React.ChangeEvent<HTMLTextAreaElement>)=>{
+        setThemeContent(e.target.value);
+    }
+    
     const getAIText = async () => {
         setGenerating(true);
         const systemPrompt = "You are an AI that can write SEO friendly README for github Projects. Write the content for the description section of this REAMDE in about 100 words. Use emojis, bullet points and make the README as attractive as possible.";
@@ -64,13 +70,16 @@ const CreateGuidelinesPage = ({ themeFiles, markdownPath }: Props) => {
     return (
         <div className='w-full p-4 min-h-screen h-auto bg-gray-50 dark:bg-zinc-900'>
             <CreateGuidelinesForm formData={formData} setFormData={setFormData} handleButtonClick={handleButtonClick} getAIText={getAIText} isAIGenerating={generating} />
-            <div className="w-full shadow-lg rounded-lg h-full bg-background dark:shadow-zinc-600">
+            <div className="w-full pb-2 shadow-lg rounded-lg h-full bg-background dark:shadow-zinc-600">
                 <div className="flex gap-4 w-full justify-end p-2">
                     <Button variant={"outline"} className={`h-[40px] w-[40px] p-0 ${isCopied && "bg-green-300 hover:bg-green-300"}`} onClick={handleContentCopy}>
                         {!isCopied ?
                             <CopyIcon size={20} />
                             : <Check />
                         }
+                    </Button>
+                    <Button variant={'outline'} className={`h-[40px] w-32 p-0`} onClick={()=>setIsRawMode(!isRawMode)}>
+                        {isRawMode ? 'Raw + Preview': 'Preview only'}
                     </Button>
                     <Select onValueChange={(value) => setSelectedTheme(value)}>
                         <SelectTrigger className="w-[180px]">
@@ -84,7 +93,32 @@ const CreateGuidelinesPage = ({ themeFiles, markdownPath }: Props) => {
                     </Select>
                 </div>
 
-                <RenderMarkdown themeContent={themeContent} />
+                <PanelGroup direction="horizontal">
+                    <Panel id="preview" order={1} defaultSize={isRawMode ? 49 : 100}>
+                        <div>
+                        <RenderMarkdown themeContent={themeContent} />
+                        </div>
+                    </Panel>
+                    {isRawMode ? (
+                        <>
+                            <PanelResizeHandle className="flex justify-center items-center w-px mx-4 bg-slate-600">
+                                <div className="z-10 flex h-full w-6 items-center justify-center rounded">
+                                    <GripVertical className="bg-white dark:bg-background" />
+                                </div>
+                            </PanelResizeHandle>
+                            <Panel id="raw" order={2} defaultSize={51}>
+                                <div className="h-full mr-2">
+                                <textarea 
+                                    value={themeContent} 
+                                    onChange={handleMarkdownChange}
+                                    className="w-full h-full p-4 rounded-lg text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-white"
+                                />
+                                </div>
+                            </Panel>
+                        </>
+                    ) : (<></>)
+                } 
+                </PanelGroup>
             </div>
         </div>
     )

--- a/components/pages/CreateProjectReadmePage.tsx
+++ b/components/pages/CreateProjectReadmePage.tsx
@@ -6,10 +6,11 @@ import { useToast } from "../ui/use-toast";
 import { projectReadmeFormData } from "@/types";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../ui/select";
 import { Button } from "../ui/button";
-import { Check, CopyIcon } from "lucide-react";
+import { Check, CopyIcon, GripVertical } from "lucide-react";
 import RenderMarkdown from "../RenderMarkdown";
 import CreateProjectReadmeForm from "../CreateProejctReadme";
 import { GenerateContentWithAI } from "@/actions/AIGeneration";
+import {Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 type Props = {
   themeFiles: string[];
@@ -29,6 +30,7 @@ const CreateProjectReadmePage = ({ themeFiles, markdownPath }: Props) => {
   });
   const [themeContent, setThemeContent] = useState("");
   const [isCopied, setIsCopied] = useState(false);
+  const [isRawMode, setIsRawMode] = useState(false);
   const [generating, setGenerating] = useState(false);
 
   const getThemeData = async () => {
@@ -56,6 +58,10 @@ const CreateProjectReadmePage = ({ themeFiles, markdownPath }: Props) => {
       setIsCopied(false);
     }, 2000)
   }
+  
+  const handleMarkdownChange = (e:React.ChangeEvent<HTMLTextAreaElement>)=>{
+    setThemeContent(e.target.value);
+  }
 
   const getAIText = async () => {
     setGenerating(true);
@@ -68,13 +74,16 @@ const CreateProjectReadmePage = ({ themeFiles, markdownPath }: Props) => {
   return (
     <div className='w-full p-4 min-h-screen h-auto bg-gray-50 dark:bg-gray-900'>
       <CreateProjectReadmeForm formData={formData} setFormData={setFormData} handleButtonClick={handleButtonClick} getAIText={getAIText} isAIGenerating={generating} />
-      <div className="w-full shadow-lg rounded-lg h-full bg-background dark:shadow-gray-600">
+      <div className="w-full pb-2 shadow-lg rounded-lg h-full bg-background dark:shadow-gray-600">
         <div className="flex gap-4 w-full justify-end p-2">
           <Button variant={"outline"} className={`h-[40px] w-[40px] p-0 ${isCopied && "bg-green-300 hover:bg-green-300"}`} onClick={handleContentCopy}>
             {!isCopied ?
               <CopyIcon size={20} />
               : <Check />
             }
+          </Button>
+          <Button variant={'outline'} className={`h-[40px] w-32 p-0`} onClick={()=>setIsRawMode(!isRawMode)}>
+            {isRawMode ? 'Raw + Preview': 'Preview only'}
           </Button>
           <Select onValueChange={(value) => setSelectedTheme(value)}>
             <SelectTrigger className="w-[180px]">
@@ -87,8 +96,32 @@ const CreateProjectReadmePage = ({ themeFiles, markdownPath }: Props) => {
             </SelectContent>
           </Select>
         </div>
-
-        <RenderMarkdown themeContent={themeContent} />
+        <PanelGroup direction="horizontal">
+          <Panel id="preview" order={1} defaultSize={isRawMode ? 49 : 100}>
+            <div>
+            <RenderMarkdown themeContent={themeContent} />
+            </div>
+          </Panel>
+          {isRawMode ? (
+            <>
+              <PanelResizeHandle className="flex justify-center items-center w-px mx-4 bg-slate-600">
+                <div className="z-10 flex h-full w-6 items-center justify-center rounded">
+                  <GripVertical className="bg-white dark:bg-background" />
+                </div>
+              </PanelResizeHandle>
+              <Panel id="raw" order={2} defaultSize={51}>
+                <div className="h-full mr-2">
+                <textarea 
+                  value={themeContent} 
+                  onChange={handleMarkdownChange}
+                  className="w-full h-full p-4 rounded-lg text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-white"
+                />
+                </div>
+              </Panel>
+            </>
+          ) : (<></>)
+        } 
+        </PanelGroup>
       </div>
     </div>
   )

--- a/components/pages/CreateReadmePage.tsx
+++ b/components/pages/CreateReadmePage.tsx
@@ -7,10 +7,11 @@ import React, { useEffect, useState } from 'react';
 import RenderMarkdown from '../RenderMarkdown';
 import { FormatReadmeThemeData } from '@/actions/themeDataFormat';
 import { Button } from '../ui/button';
-import { Check, CopyIcon } from 'lucide-react';
+import { Check, CopyIcon, GripVertical } from 'lucide-react';
 import { useToast } from '../ui/use-toast';
 import { allLanguages } from '@/constants';
 import { GenerateContentWithAI } from '@/actions/AIGeneration';
+import {Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 
 type Props = {
     themeFiles: string[];
@@ -34,6 +35,7 @@ const CreateReadmePage = ({ themeFiles, markdownPath }: Props) => {
     });
     const [themeContent, setThemeContent] = useState("");
     const [isCopied, setIsCopied] = useState(false);
+    const [isRawMode, setIsRawMode] = useState(false);
     const [generating, setGenerating] = useState(false);
 
     const getThemeData = async () => {
@@ -61,6 +63,10 @@ const CreateReadmePage = ({ themeFiles, markdownPath }: Props) => {
             setIsCopied(false);
         }, 2000)
     }
+    
+    const handleMarkdownChange = (e:React.ChangeEvent<HTMLTextAreaElement>)=>{
+        setThemeContent(e.target.value);
+    }
 
     const getAIText = async () => {
         setGenerating(true);
@@ -73,13 +79,16 @@ const CreateReadmePage = ({ themeFiles, markdownPath }: Props) => {
     return (
         <div className='w-full p-4 min-h-screen h-auto bg-gray-50 dark:bg-gray-900'>
             <CreateReadmeForm formData={formData} setFormData={setFormData} handleButtonClick={handleButtonClick} getAIText={getAIText} isAIGenerating={generating} />
-            <div className="w-full shadow-lg rounded-lg h-full bg-card dark:shadow-gray-800">
+            <div className="w-full pb-2 shadow-lg rounded-lg h-full bg-card dark:shadow-gray-800">
                 <div className="flex gap-4 w-full justify-end p-2">
                     <Button variant={"outline"} className={`h-[40px] w-[40px] p-0 ${isCopied && "bg-green-300 hover:bg-green-300"}`} onClick={handleContentCopy}>
                         {!isCopied ?
                             <CopyIcon size={20} />
                             : <Check />
                         }
+                    </Button>
+                    <Button variant={'outline'} className={`h-[40px] w-32 p-0`} onClick={()=>setIsRawMode(!isRawMode)}>
+                        {isRawMode ? 'Raw + Preview': 'Preview only'}
                     </Button>
                     <Select onValueChange={(value) => setSelectedTheme(value)}>
                         <SelectTrigger className="w-[180px]">
@@ -93,7 +102,32 @@ const CreateReadmePage = ({ themeFiles, markdownPath }: Props) => {
                     </Select>
                 </div>
 
-                <RenderMarkdown themeContent={themeContent} />
+                <PanelGroup direction="horizontal">
+                    <Panel id="preview" order={1} defaultSize={isRawMode ? 49 : 100}>
+                        <div>
+                        <RenderMarkdown themeContent={themeContent} />
+                        </div>
+                    </Panel>
+                    {isRawMode ? (
+                        <>
+                            <PanelResizeHandle className="flex justify-center items-center w-px mx-4 bg-slate-600">
+                                <div className="z-10 flex h-full w-6 items-center justify-center rounded">
+                                    <GripVertical className="bg-white dark:bg-background" />
+                                </div>
+                            </PanelResizeHandle>
+                            <Panel id="raw" order={2} defaultSize={51}>
+                                <div className="h-full mr-2">
+                                <textarea 
+                                    value={themeContent} 
+                                    onChange={handleMarkdownChange}
+                                    className="w-full h-full p-4 rounded-lg text-gray-600 bg-gray-100 dark:bg-gray-800 dark:text-white"
+                                />
+                                </div>
+                            </Panel>
+                        </>
+                    ) : (<></>)
+                } 
+                </PanelGroup>
             </div>
         </div>
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-markdown": "^9.0.1",
+        "react-resizable-panels": "^2.1.6",
         "rehype-raw": "^7.0.0",
         "tailwind-merge": "^2.5.3",
         "tailwindcss-animate": "^1.0.7"
@@ -3048,6 +3049,15 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resizable-panels": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/react-resizable-panels/-/react-resizable-panels-2.1.6.tgz",
+      "integrity": "sha512-oIqo/7pp2TsR+Dp1qZMr1l4RBDV4Zz/0HEG5zxliBJoHqqFnG0MbmFbk+5Q1VMGfPQ4uhXxefunLC1o7v38PDQ==",
+      "peerDependencies": {
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-markdown": "^9.0.1",
+    "react-resizable-panels": "^2.1.6",
     "rehype-raw": "^7.0.0",
     "tailwind-merge": "^2.5.3",
     "tailwindcss-animate": "^1.0.7"


### PR DESCRIPTION
Solves #18 

**Description-**
Created a toggle button for Raw markdown code view.
Changes made in Raw markdown editor are reflected in preview. Raw view and Preview are opened side by side with resizing panels.

**Additional Details-**
Added additional dependency for resizing panels - 
``` npm i react-resizable-panels```

**Acceptance Criteria**

- [x] Raw view is created
- [x] Changes in raw view are reflected in preview view
- [x] Does not break the existing code
